### PR TITLE
Refactor to effect-driven architecture instead of mutable update loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,20 +1,179 @@
+use std::sync::mpsc;
+
 /// We derive Deserialize/Serialize so we can persist app state on shutdown.
 #[derive(serde::Deserialize, serde::Serialize)]
 #[serde(default)] // if we add new fields, give them default values when deserializing old state
-pub struct StickiesApp {
+pub struct AppState {
+    #[serde(skip_serializing, skip_deserializing)]
+    effects_tx: mpsc::Sender<Effect>,
+    #[serde(skip_serializing, skip_deserializing)]
+    effects_rx: mpsc::Receiver<Effect>,
+    
     draft: String,
-    checked: bool,
     todos: Vec<Todo>,
 }
 
-impl Default for StickiesApp {
+impl Default for AppState {
     fn default() -> Self {
+        let (effects_tx, effects_rx) = mpsc::channel();
+        
         Self {
+            effects_tx,
+            effects_rx,
+            
             draft: "Feed doge".to_owned(),
-            checked: false,
             todos: vec![Todo::new(String::from("Water plants"))],
         }
     }
+}
+
+impl AppState {
+    /// Called once before the first frame.
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+        // This is also where you can customize the look and feel of egui using
+        // `cc.egui_ctx.set_visuals` and `cc.egui_ctx.set_fonts`.
+
+        // Load previous app state (if any).
+        // Note that you must enable the `persistence` feature for this to work.
+        if let Some(storage) = cc.storage {
+            return eframe::get_value(storage, eframe::APP_KEY).unwrap_or_default();
+        }
+
+        Default::default()
+    }
+
+    fn apply_effects(&mut self) {
+        while let Ok(effect) = self.effects_rx.try_recv() {
+            match effect {
+                Effect::DraftTodo(draft) => {
+                    self.draft = draft;
+                }
+                Effect::AddTodo(label) => {
+                    self.todos.push(Todo::new(label));
+                    self.draft.clear();
+                }
+                Effect::EditTodo(index) => {
+                    if let Some(todo) = self.todos.get_mut(index) {
+                        todo.edit_mode = !todo.edit_mode;
+                    }
+                }
+                Effect::SaveTodo(index, label) => {
+                    if let Some(todo) = self.todos.get_mut(index) {
+                        todo.label = label;
+                    }
+                }
+                Effect::CheckTodo(index) => {
+                    if let Some(todo) = self.todos.get_mut(index) {
+                        todo.checked = !todo.checked;
+                    }
+                }
+                Effect::DeleteTodo(index) => {
+                    if index < self.todos.len() {
+                        self.todos.remove(index);
+                    }
+                }
+            }
+        }
+    }
+
+    fn render(&self, ctx: &egui::Context) {
+        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
+            egui::menu::bar(ui, |ui| {
+                egui::widgets::global_dark_light_mode_buttons(ui);
+            });
+        });
+
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.vertical_centered(|ui| {
+                ui.heading("Stickies");
+            });
+
+            ui.add_space(10.0);
+
+            ui.horizontal(|ui| {
+                ui.label("Add a sticky: ");
+
+                let mut local_draft = self.draft.clone();
+                if ui.text_edit_singleline(&mut local_draft).lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                    self.effects_tx.send(Effect::AddTodo(local_draft.clone())).unwrap();
+                    local_draft.clear();
+                }
+
+                if ui.button("Save").clicked() {
+                    self.effects_tx.send(Effect::AddTodo(local_draft.clone())).unwrap();
+                    local_draft.clear();
+                }
+
+                self.effects_tx.send(Effect::DraftTodo(local_draft)).unwrap();
+            });
+
+            ui.add_space(10.0);
+            
+            for (index, todo) in self.todos.iter().enumerate() {
+                // TODO: make this a draggable sticky instead of a row
+                ui.horizontal(|ui| {
+                    let mut local_checked = todo.checked;
+                    if ui.checkbox(&mut local_checked, "").changed() {
+                        self.effects_tx.send(Effect::CheckTodo(index)).unwrap();
+                    }
+                    let mut local_label = todo.label.clone();
+                    if todo.edit_mode {
+                        if ui.text_edit_singleline(&mut local_label).lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+                            self.effects_tx.send(Effect::EditTodo(index)).unwrap();
+                            self.effects_tx.send(Effect::SaveTodo(index, local_label.clone())).unwrap();
+                        }
+
+                        self.effects_tx.send(Effect::SaveTodo(index, local_label.clone())).unwrap();
+                    } else {
+                        ui.label(&todo.label);
+                    }
+                    
+                    if todo.edit_mode {
+                        if ui.button("Save").clicked() {
+                            self.effects_tx.send(Effect::EditTodo(index)).unwrap();
+                            self.effects_tx.send(Effect::SaveTodo(index, local_label.clone())).unwrap();
+                        }
+                    } else {
+                        if ui.button("Edit").clicked() {
+                            self.effects_tx.send(Effect::EditTodo(index)).unwrap();
+                        }
+                    }
+                    
+                    if ui.button("Delete").clicked() {
+                        self.effects_tx.send(Effect::DeleteTodo(index)).unwrap();
+                    }
+                });
+            }
+            
+            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
+                ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 0.0;
+                    ui.add(egui::github_link_file!(
+                        "https://github.com/pmillspaugh/stickies/blob/main/",
+                        "Source code. "
+                    ));
+                    ui.label("Powered by ");
+                    ui.hyperlink_to("egui", "https://github.com/emilk/egui");
+                    ui.label(" and ");
+                    ui.hyperlink_to(
+                        "eframe",
+                        "https://github.com/emilk/egui/tree/master/crates/eframe",
+                    );
+                    ui.label(".");
+                });
+                egui::warn_if_debug_build(ui);
+            });
+        });
+    }
+}
+
+enum Effect {
+    DraftTodo(String),
+    AddTodo(String),
+    EditTodo(usize),
+    SaveTodo(usize, String),
+    CheckTodo(usize),
+    DeleteTodo(usize),
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -34,23 +193,7 @@ impl Todo {
     }
 }
 
-impl StickiesApp {
-    /// Called once before the first frame.
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        // This is also where you can customize the look and feel of egui using
-        // `cc.egui_ctx.set_visuals` and `cc.egui_ctx.set_fonts`.
-
-        // Load previous app state (if any).
-        // Note that you must enable the `persistence` feature for this to work.
-        if let Some(storage) = cc.storage {
-            return eframe::get_value(storage, eframe::APP_KEY).unwrap_or_default();
-        }
-
-        Default::default()
-    }
-}
-
-impl eframe::App for StickiesApp {
+impl eframe::App for AppState {
     /// Called by the frame work to save state before shutdown.
     fn save(&mut self, storage: &mut dyn eframe::Storage) {
         eframe::set_value(storage, eframe::APP_KEY, self);
@@ -58,83 +201,7 @@ impl eframe::App for StickiesApp {
 
     /// Called each time the UI needs repainting, which may be many times per second.
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Put your widgets into a `SidePanel`, `TopBottomPanel`, `CentralPanel`, `Window` or `Area`.
-        // For inspiration and more examples, go to https://emilk.github.io/egui
-
-        egui::TopBottomPanel::top("top_panel").show(ctx, |ui| {
-            egui::menu::bar(ui, |ui| {
-                egui::widgets::global_dark_light_mode_buttons(ui);
-            });
-        });
-
-        egui::CentralPanel::default().show(ctx, |ui| {
-            // The central panel the region left after adding TopPanel's and SidePanel's
-            ui.heading("stickies");
-
-            ui.add_space(10.0);
-
-            ui.horizontal(|ui| {
-                ui.label("Add a sticky: ");
-                ui.text_edit_singleline(&mut self.draft);
-
-                // TODO: pressing Enter should also save a todo
-                if ui.button("Save").clicked() {
-                    self.todos.push(Todo::new(String::from(self.draft.clone())));
-                    self.draft.clear();
-                }
-            });
-
-            ui.add_space(10.0);
-
-            let mut to_delete = None;
-            for todo in &mut self.todos {
-                // TODO: make this a draggable sticky instead of a row
-                ui.horizontal(|ui| {
-                    ui.checkbox(&mut todo.checked, "");
-                    
-                    if todo.edit_mode {
-                        ui.text_edit_singleline(&mut todo.label);
-                    } else {
-                        ui.label(todo.label.clone());
-                    }
-
-                    let edit_button_text = if todo.edit_mode { "Save" } else { "Edit" };
-                    if ui.button(edit_button_text).on_hover_text("Re-write sticky").clicked() {
-                        todo.edit_mode = !todo.edit_mode;
-                    }
-
-                    if ui.button("Delete").on_hover_text("Throw away sticky").clicked() {
-                        to_delete = Some(todo.label.clone());
-                    }
-                });
-            }
-
-            if let Some(to_delete) = to_delete {
-                self.todos.retain(|t| t.label != to_delete);
-            }
-
-            ui.with_layout(egui::Layout::bottom_up(egui::Align::LEFT), |ui| {
-                powered_by_egui_and_eframe(ui);
-                egui::warn_if_debug_build(ui);
-            });
-        });
+        self.render(ctx);
+        self.apply_effects();
     }
-}
-
-fn powered_by_egui_and_eframe(ui: &mut egui::Ui) {
-    ui.horizontal(|ui| {
-        ui.spacing_mut().item_spacing.x = 0.0;
-        ui.add(egui::github_link_file!(
-            "https://github.com/pmillspaugh/stickies/blob/main/",
-            "Source code. "
-        ));
-        ui.label("Powered by ");
-        ui.hyperlink_to("egui", "https://github.com/emilk/egui");
-        ui.label(" and ");
-        ui.hyperlink_to(
-            "eframe",
-            "https://github.com/emilk/egui/tree/master/crates/eframe",
-        );
-        ui.label(".");
-    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 mod app;
-pub use app::StickiesApp;
+pub use app::AppState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> eframe::Result<()> {
     eframe::run_native(
         "stickies",
         native_options,
-        Box::new(|cc| Box::new(stickies::StickiesApp::new(cc))),
+        Box::new(|cc| Box::new(stickies::AppState::new(cc))),
     )
 }
 
@@ -37,7 +37,7 @@ fn main() {
             .start(
                 "the_canvas_id", // hardcode it
                 web_options,
-                Box::new(|cc| Box::new(stickies::StickiesApp::new(cc))),
+                Box::new(|cc| Box::new(stickies::AppState::new(cc))),
             )
             .await
             .expect("failed to start eframe");


### PR DESCRIPTION
Same functionality as before (plus you can press Enter to save).

https://github.com/pmillspaugh/stickies/assets/73900714/858fd9d4-a34c-4d5d-a652-769af60afcd2